### PR TITLE
Remove funding_uri from gem metadata

### DIFF
--- a/enveloperb.gemspec
+++ b/enveloperb.gemspec
@@ -30,7 +30,6 @@ Gem::Specification.new do |s|
   s.metadata["bug_tracker_uri"] = "https://github.com/cipherstash/enveloperb/issues"
   s.metadata["documentation_uri"] = "https://rubydoc.info/gems/enveloperb"
   s.metadata["mailing_list_uri"] = "https://discuss.cipherstash.com"
-  s.metadata["funding_uri"] = "https://cipherstash.com/pricing"
 
   s.add_development_dependency 'bundler'
   s.add_development_dependency 'github-release'


### PR DESCRIPTION
Removing funding_uri since we decided that it's more annoying than actually helpful.