### PR TITLE
Update envelopers to 0.5.1, enable tokio

### DIFF
--- a/ext/enveloperb/Cargo.lock
+++ b/ext/enveloperb/Cargo.lock
@@ -567,9 +567,9 @@ dependencies = [
 
 [[package]]
 name = "envelopers"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c3cc2fe803e7f222ba13524bad71c8f99fb4147fec2d088010fa40ffd5c4914"
+checksum = "ea1989c57e324387ae456656f0cdb0b48641329a0a934bddaa4e722e3095becc"
 dependencies = [
  "aes-gcm",
  "async-trait",

--- a/ext/enveloperb/Cargo.toml
+++ b/ext/enveloperb/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.0.0"
 edition = "2021"
 
 [dependencies]
-envelopers = "0.5"
+envelopers = { version = "0.5.1", features = [ "tokio" ] }
 lazy_static = "^0.2.2"
 rb-sys = "0.8.0"
 rutie = { git = "https://github.com/mpalmer/rutie", branch = "rb_sys" }


### PR DESCRIPTION
Updates envelopers to 0.5.1 and enabled tokio to enable retries.
